### PR TITLE
Fix concurrency issues by removing file access

### DIFF
--- a/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -44,9 +44,6 @@
     <Compile Include="XmlLicenseTransformTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\tests\System\IO\TempFile.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="EncryptedXmlSample3.xml" />
     <EmbeddedResource Include="EncryptedXmlSample2.xml" />
     <EmbeddedResource Include="EncryptedXmlSample1.xml" />

--- a/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -10,59 +10,8 @@ using System.Xml.Resolvers;
 
 namespace System.Security.Cryptography.Xml.Tests
 {
-    public class TempFile : IDisposable
-    {
-        public TempFile(string fileName)
-        {
-            Path = fileName;
-        }
-
-        public string Path {  get; }
-
-        public void Dispose()
-        {
-    
-        }
-    }
-
     internal static class TestHelpers
     {
-        public static TempFile CreateTestDtdFile(string testName)
-        {
-            if (testName == null)
-                throw new ArgumentNullException(nameof(testName));
-
-            var file = new TempFile(
-                Path.Combine(Directory.GetCurrentDirectory(), testName + ".dtd")
-            );
-
-            File.WriteAllText(file.Path, "<!-- presence, not content, required -->");
-
-            return file;
-        }
-
-        public static TempFile CreateTestTextFile(string testName, string content)
-        {
-            if (testName == null)
-                throw new ArgumentNullException(nameof(testName));
-
-            if (content == null)
-                throw new ArgumentNullException(nameof(content));
-
-            var file = new TempFile(
-                Path.Combine(Directory.GetCurrentDirectory(), testName + ".txt")
-            );
-
-            File.WriteAllText(file.Path, content);
-
-            return file;
-        }
-
-        public static string EscapePath(string path)
-        {
-            return path.Replace("-", "&#2D;");
-        }
-
         /// <summary>
         /// Convert a <see cref="Stream"/> to a <see cref="string"/> using the given <see cref="Encoding"/>.
         /// </summary>

--- a/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -2,10 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
+using System.Text;
+using System.Xml;
 
 namespace System.Security.Cryptography.Xml.Tests
 {
+    public class TempFile : IDisposable
+    {
+        public TempFile(string fileName)
+        {
+            Path = fileName;
+        }
+
+        public string Path {  get; }
+
+        public void Dispose()
+        {
+    
+        }
+    }
+
     internal static class TestHelpers
     {
         public static TempFile CreateTestDtdFile(string testName)
@@ -42,6 +60,97 @@ namespace System.Security.Cryptography.Xml.Tests
         public static string EscapePath(string path)
         {
             return path.Replace("-", "&#2D;");
+        }
+
+        /// <summary>
+        /// Convert a <see cref="Stream"/> to a <see cref="string"/> using the given <see cref="Encoding"/>.
+        /// </summary>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to read from. This cannot be null.
+        /// </param>
+        /// <param name="encoding">
+        /// The <see cref="Encoding"/> to use. This cannot be null.
+        /// </param>
+        /// <returns>
+        /// The stream as a string.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// No argument can be null.
+        /// </exception>
+        public static string StreamToString(Stream stream, Encoding encoding)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            using (StreamReader streamReader = new StreamReader(stream, encoding))
+            {
+                return streamReader.ReadToEnd();
+            }
+        }
+
+        /// <summary>
+        /// Perform
+        /// </summary>
+        /// <param name="inputXml">
+        /// The XML to transform. This cannot be null, empty or whitespace.
+        /// </param>
+        /// <param name="transform">
+        /// The <see cref="Transform"/> to perform on 
+        /// <paramref name="inputXml"/>. This cannot be null.
+        /// </param>
+        /// <param name="encoding">
+        /// An optional <see cref="Encoding"/> to use when serializing or 
+        /// deserializing <paramref name="inputXml"/>. This should match the 
+        /// encoding specified in <paramref name="inputXml"/>. If omitted or 
+        /// null, <see cref="UTF8Encoding"/> is used.
+        /// </param>
+        /// <param name="resolver">
+        /// An optional <see cref="XmlResolver"/> to use. If omitted or null, 
+        /// no resolver is used.
+        /// </param>
+        /// <returns>
+        /// The transformed <paramref name="inputXml"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="transform"/> cannot be null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="inputXml"/> cannot be null, empty or whitespace.
+        /// </exception>
+        /// <exception cref="XmlException">
+        /// <paramref name="inputXml"/> is not valid XML.
+        /// </exception>
+        public static string ExecuteTransform(string inputXml, Transform transform, Encoding encoding = null, XmlResolver resolver = null)
+        {
+            if (string.IsNullOrEmpty(inputXml))
+            {
+                throw new ArgumentException("Cannot be null, empty or whitespace", nameof(inputXml));
+            }
+            if (transform == null)
+            {
+                throw new ArgumentNullException(nameof(Transform));
+            }
+
+            XmlDocument doc = new XmlDocument();
+            doc.XmlResolver = resolver;
+            doc.PreserveWhitespace = true;
+            doc.LoadXml(inputXml);
+
+            Encoding actualEncoding = encoding ?? Encoding.UTF8;
+            byte[] data = actualEncoding.GetBytes(inputXml);
+            using (Stream stream = new MemoryStream(data))
+            using (XmlReader reader = XmlReader.Create(stream, new XmlReaderSettings { ValidationType = ValidationType.None, DtdProcessing = DtdProcessing.Parse, XmlResolver = resolver }))
+            {
+                doc.Load(reader);
+                transform.LoadInput(doc);
+                return StreamToString((Stream)transform.GetOutput(), actualEncoding);
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Xml;
+using System.Xml.Resolvers;
 
 namespace System.Security.Cryptography.Xml.Tests
 {
@@ -151,6 +152,21 @@ namespace System.Security.Cryptography.Xml.Tests
                 transform.LoadInput(doc);
                 return StreamToString((Stream)transform.GetOutput(), actualEncoding);
             }
+        }
+
+        /// <summary>
+        /// Convert <paramref name="fileName"/> to a full URI for referencing 
+        /// in an <see cref="XmlPreloadedResolver"/>.
+        /// </summary>
+        /// <param name="fileName">
+        /// The file name.
+        /// </param>
+        /// <returns>
+        /// The created <see cref="Uri"/>.
+        /// </returns>
+        public static Uri ToUri(string fileName)
+        {
+            return new Uri("file:///" + Path.Combine(Directory.GetCurrentDirectory(), fileName));
         }
     }
 }

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
@@ -156,8 +156,8 @@ namespace System.Security.Cryptography.Xml.Tests
         {
             XmlPreloadedResolver resolver = new XmlPreloadedResolver();
             resolver.Add(new Uri("doc.xsl", UriKind.Relative), "");
-            string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input, resolver);
-            Assert.Equal(C14NSpecExample1Output, res);
+            string result = TestHelpers.ExecuteTransform(C14NSpecExample1Input, new XmlDsigC14NTransform());
+            Assert.Equal(C14NSpecExample1Output, result);
         }
 
         [Theory]
@@ -166,7 +166,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [InlineData(C14NSpecExample4Input, C14NSpecExample4Output)]
         public void C14NSpecExample(string input, string expectedOutput)
         {
-            string result = ExecuteXmlDSigC14NTransform(input);
+            string result = TestHelpers.ExecuteTransform(input, new XmlDsigC14NTransform());
             Assert.Equal(expectedOutput, result);
         }
 
@@ -175,38 +175,15 @@ namespace System.Security.Cryptography.Xml.Tests
         {
             XmlPreloadedResolver resolver = new XmlPreloadedResolver();
             resolver.Add(new Uri("file://doc.txt"), "world");
-            string res = ExecuteXmlDSigC14NTransform(C14NSpecExample5Input, resolver);
-            Assert.Equal(C14NSpecExample5Output, res);
+            string result = TestHelpers.ExecuteTransform(C14NSpecExample5Input, new XmlDsigC14NTransform(), Encoding.UTF8, resolver);
+            Assert.Equal(C14NSpecExample5Output, result);
         }
 
         [Fact]
         public void C14NSpecExample6()
         {
-            string res = TestHelpers.ExecuteTransform(C14NSpecExample6Input, new XmlDsigC14NTransform(), Encoding.GetEncoding("ISO-8859-1"));
-            Assert.Equal(C14NSpecExample6Output, res);
-        }
-
-        private string ExecuteXmlDSigC14NTransform(string InputXml, XmlResolver resolver = null)
-        {
-            XmlDsigC14NTransform transform = new XmlDsigC14NTransform();
-            XmlDocument doc = new XmlDocument();
-            doc.PreserveWhitespace = true;
-            doc.XmlResolver = resolver;
-            doc.LoadXml(InputXml);
-
-            // Testing default attribute support with
-            // vreader.ValidationType = ValidationType.None.
-            //
-            UTF8Encoding utf8 = new UTF8Encoding();
-            byte[] data = utf8.GetBytes(InputXml.ToString());
-            Stream stream = new MemoryStream(data);
-            using (XmlReader reader = XmlReader.Create(stream, new XmlReaderSettings { ValidationType = ValidationType.None, DtdProcessing = DtdProcessing.Parse, XmlResolver = resolver}))
-            {
-                doc.Load(reader);
-
-                transform.LoadInput(doc);
-                return TestHelpers.StreamToString((Stream)transform.GetOutput(), utf8);
-            }
+            string result = TestHelpers.ExecuteTransform(C14NSpecExample6Input, new XmlDsigC14NTransform(), Encoding.GetEncoding("ISO-8859-1"));
+            Assert.Equal(C14NSpecExample6Output, result);
         }
 
         //

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
@@ -174,7 +174,7 @@ namespace System.Security.Cryptography.Xml.Tests
         public void C14NSpecExample5()
         {
             XmlPreloadedResolver resolver = new XmlPreloadedResolver();
-            resolver.Add(new Uri("file://doc.txt"), "world");
+            resolver.Add(TestHelpers.ToUri("doc.txt"), "world");
             string result = TestHelpers.ExecuteTransform(C14NSpecExample5Input, new XmlDsigC14NTransform(), Encoding.UTF8, resolver);
             Assert.Equal(C14NSpecExample5Output, result);
         }
@@ -320,7 +320,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 "<!DOCTYPE doc [\n" +
                 "<!ATTLIST doc attrExtEnt ENTITY #IMPLIED>\n" +
                 "<!ENTITY ent1 \"Hello\">\n" +
-                $"<!ENTITY ent2 SYSTEM \"file://doc.txt\">\n" +
+                $"<!ENTITY ent2 SYSTEM \"doc.txt\">\n" +
                 "<!ENTITY entExt SYSTEM \"earth.gif\" NDATA gif>\n" +
                 "<!NOTATION gif SYSTEM \"viewgif.exe\">\n" +
                 "]>\n" +

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
@@ -71,23 +71,10 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void C14NSpecExample1()
         {
-            string testName = GetType().Name + "." + nameof(C14NSpecExample1);
-            using (TestHelpers.CreateTestDtdFile(testName))
-            {
-                string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input(testName), Encoding.UTF8, new XmlUrlResolver());
-                Assert.Equal(C14NSpecExample1Output, res);
-            }
-        }
-
-        [Fact]
-        public void C14NSpecExample1_WithoutResolver()
-        {
-            string testName = GetType().Name + "." + nameof(C14NSpecExample1_WithoutResolver);
-            using (TestHelpers.CreateTestDtdFile(testName))
-            {
-                string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input(testName));
-                Assert.Equal(C14NSpecExample1Output, res);
-            }
+            XmlPreloadedResolver resolver = new XmlPreloadedResolver();
+            resolver.Add(TestHelpers.ToUri("world.dtd"), "");
+            string res = TestHelpers.ExecuteTransform(C14NSpecExample1Input, new XmlDsigC14NWithCommentsTransform(), Encoding.UTF8, resolver);
+            Assert.Equal(C14NSpecExample1Output, res);
         }
 
         [Theory]
@@ -102,12 +89,11 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void C14NSpecExample5()
         {
-            string entityPath = "file://doc.txt";
             XmlPreloadedResolver resolver = new XmlPreloadedResolver();
-            resolver.Add(new Uri(entityPath), "world");
-            string input = C14NSpecExample5Input(entityPath);
+            resolver.Add(TestHelpers.ToUri("doc.txt"), "world");
+            string input = C14NSpecExample5Input;
             string result = ExecuteXmlDSigC14NTransform(input, Encoding.UTF8, resolver);
-            string expectedResult = C14NSpecExample5Output(entityPath);
+            string expectedResult = C14NSpecExample5Output;
             Assert.Equal(expectedResult, result);
         }
 
@@ -141,13 +127,13 @@ namespace System.Security.Cryptography.Xml.Tests
         // Example 1 from C14N spec - PIs, Comments, and Outside of Document Element: 
         // http://www.w3.org/TR/xml-c14n#Example-OutsideDoc
         //
-        static string C14NSpecExample1Input(string testName) =>
+        static string C14NSpecExample1Input =>
             "<?xml version=\"1.0\"?>\n" +
                 "\n" +
                 "<?xml-stylesheet   href=\"doc.xsl\"\n" +
                 "   type=\"text/xsl\"   ?>\n" +
                 "\n" +
-                $"<!DOCTYPE doc SYSTEM \"{Path.GetFullPath(testName + ".dtd")}\">\n" +
+                "<!DOCTYPE doc SYSTEM \"world.dtd\">\n" +
                 "\n" +
                 "<doc>Hello, world!<!-- Comment 1 --></doc>\n" +
                 "\n" +
@@ -267,11 +253,11 @@ namespace System.Security.Cryptography.Xml.Tests
         // Example 5 from C14N spec - Entity References: 
         // http://www.w3.org/TR/xml-c14n#Example-Entities
         //
-        static string C14NSpecExample5Input(string path) =>
+        static string C14NSpecExample5Input =>
                 "<!DOCTYPE doc [\n" +
                 "<!ATTLIST doc attrExtEnt ENTITY #IMPLIED>\n" +
                 "<!ENTITY ent1 \"Hello\">\n" +
-                $"<!ENTITY ent2 SYSTEM \"{TestHelpers.EscapePath(path)}\">\n" +
+                $"<!ENTITY ent2 SYSTEM \"doc.txt\">\n" +
                 "<!ENTITY entExt SYSTEM \"earth.gif\" NDATA gif>\n" +
                 "<!NOTATION gif SYSTEM \"viewgif.exe\">\n" +
                 "]>\n" +
@@ -279,12 +265,12 @@ namespace System.Security.Cryptography.Xml.Tests
                 "   &ent1;, &ent2;!\n" +
                 "</doc>\n" +
                 "\n" +
-                $"<!-- Let {TestHelpers.EscapePath(path)} contain \"world\" (excluding the quotes) -->\n";
-        static string C14NSpecExample5Output(string path) =>
+                $"<!-- Let doc.txt contain \"world\" (excluding the quotes) -->\n";
+        static string C14NSpecExample5Output =>
                 "<doc attrExtEnt=\"entExt\">\n" +
                 "   Hello, world!\n" +
                 "</doc>\n" +
-                $"<!-- Let {TestHelpers.EscapePath(path)} contain \"world\" (excluding the quotes) -->";
+                $"<!-- Let doc.txt contain \"world\" (excluding the quotes) -->";
 
         //
         // Example 6 from C14N spec - UTF-8 Encoding: 

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
@@ -133,15 +133,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 doc.Load(reader);
                 XmlDsigC14NWithCommentsTransform transform = new XmlDsigC14NWithCommentsTransform();
                 transform.LoadInput(doc);
-                return Stream2String((Stream) transform.GetOutput(), actualEncoding);
-            }
-        }
-
-        private string Stream2String(Stream stream, Encoding encoding)
-        {
-            using (StreamReader streamReader = new StreamReader(stream, encoding))
-            {
-                return streamReader.ReadToEnd();
+                return TestHelpers.StreamToString((Stream) transform.GetOutput(), actualEncoding);
             }
         }
 

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
@@ -14,6 +14,7 @@
 using System.IO;
 using System.Text;
 using System.Xml;
+using System.Xml.Resolvers;
 using Xunit;
 
 namespace System.Security.Cryptography.Xml.Tests
@@ -101,14 +102,13 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void C14NSpecExample5()
         {
-            string testName = GetType().Name + "." + nameof(C14NSpecExample5);
-            using (TempFile tempFile = TestHelpers.CreateTestTextFile(testName, "world"))
-            {
-                string input = C14NSpecExample5Input(tempFile.Path);
-                string result = ExecuteXmlDSigC14NTransform(input, Encoding.UTF8, new XmlUrlResolver());
-                string expectedResult = C14NSpecExample5Output(tempFile.Path);
-                Assert.Equal(expectedResult, result);
-            }
+            string entityPath = "file://doc.txt";
+            XmlPreloadedResolver resolver = new XmlPreloadedResolver();
+            resolver.Add(new Uri(entityPath), "world");
+            string input = C14NSpecExample5Input(entityPath);
+            string result = ExecuteXmlDSigC14NTransform(input, Encoding.UTF8, resolver);
+            string expectedResult = C14NSpecExample5Output(entityPath);
+            Assert.Equal(expectedResult, result);
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
@@ -326,10 +326,9 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void ExcC14NSpecExample5()
         {
-            string entityPath = "file://doc.txt";
             XmlPreloadedResolver resolver = new XmlPreloadedResolver();
-            resolver.Add(new Uri(entityPath), "world");
-            string input = ExcC14NSpecExample5Input(entityPath);
+            resolver.Add(TestHelpers.ToUri("doc.txt"), "world");
+            string input = ExcC14NSpecExample5Input;
             string res = ExecuteXmlDSigExcC14NTransform(input, resolver);
             Assert.Equal(ExcC14NSpecExample5Output, res);
         }
@@ -499,11 +498,11 @@ namespace System.Security.Cryptography.Xml.Tests
         // Example 5 from ExcC14N spec - Entity References: 
         // http://www.w3.org/TR/xml-c14n#Example-Entities
         //
-        static string ExcC14NSpecExample5Input(string path) =>
+        static string ExcC14NSpecExample5Input =>
                 "<!DOCTYPE doc [\n" +
                 "<!ATTLIST doc attrExtEnt ENTITY #IMPLIED>\n" +
                 "<!ENTITY ent1 \"Hello\">\n" +
-                $"<!ENTITY ent2 SYSTEM \"{TestHelpers.EscapePath(path)}\">\n" +
+                $"<!ENTITY ent2 SYSTEM \"doc.txt\">\n" +
                 "<!ENTITY entExt SYSTEM \"earth.gif\" NDATA gif>\n" +
                 "<!NOTATION gif SYSTEM \"viewgif.exe\">\n" +
                 "]>\n" +
@@ -511,7 +510,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 "   &ent1;, &ent2;!\n" +
                 "</doc>\n" +
                 "\n" +
-                $"<!-- Let {TestHelpers.EscapePath(path)} contain \"world\" (excluding the quotes) -->\n";
+                $"<!-- Let doc.txt contain \"world\" (excluding the quotes) -->\n";
         static string ExcC14NSpecExample5Output =
                 "<doc attrExtEnt=\"entExt\">\n" +
                 "   Hello, world!\n" +

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
@@ -293,12 +293,10 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void ExcC14NSpecExample1()
         {
-            string testName = GetType().Name + "." + nameof(ExcC14NSpecExample1);
-            using (TestHelpers.CreateTestDtdFile(testName))
-            {
-                string res = ExecuteXmlDSigExcC14NTransform(ExcC14NSpecExample1Input);
-                Assert.Equal(ExcC14NSpecExample1Output, res);
-            }
+            XmlPreloadedResolver resolver = new XmlPreloadedResolver();
+            resolver.Add(TestHelpers.ToUri("doc.dtd"), "");
+            string res = ExecuteXmlDSigExcC14NTransform(ExcC14NSpecExample1Input);
+            Assert.Equal(ExcC14NSpecExample1Output, res);
         }
 
         [Fact]
@@ -380,7 +378,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 "<?xml-stylesheet   href=\"doc.xsl\"\n" +
                 "   type=\"text/xsl\"   ?>\n" +
                 "\n" +
-                // "<!DOCTYPE doc SYSTEM \"doc.dtd\">\n" +
+                "<!DOCTYPE doc SYSTEM \"doc.dtd\">\n" +
                 "\n" +
                 "<doc>Hello, world!<!-- Comment 1 --></doc>\n" +
                 "\n" +

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
@@ -19,6 +19,7 @@
 using System.IO;
 using System.Text;
 using System.Xml;
+using System.Xml.Resolvers;
 using Xunit;
 
 namespace System.Security.Cryptography.Xml.Tests
@@ -325,13 +326,12 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void ExcC14NSpecExample5()
         {
-            string testName = GetType().Name + "." + nameof(ExcC14NSpecExample5);
-            using (TempFile tempFile = TestHelpers.CreateTestTextFile(testName, "world"))
-            {
-                string input = ExcC14NSpecExample5Input(tempFile.Path);
-                string res = ExecuteXmlDSigExcC14NTransform(input, new XmlUrlResolver());
-                Assert.Equal(ExcC14NSpecExample5Output, res);
-            }
+            string entityPath = "file://doc.txt";
+            XmlPreloadedResolver resolver = new XmlPreloadedResolver();
+            resolver.Add(new Uri(entityPath), "world");
+            string input = ExcC14NSpecExample5Input(entityPath);
+            string res = ExecuteXmlDSigExcC14NTransform(input, resolver);
+            Assert.Equal(ExcC14NSpecExample5Output, res);
         }
 
         [Fact]


### PR DESCRIPTION
I have replaced all `XmlUrlResolver` uses that reference files, usually using @tintoy 's create temp file methods, with `XmlPreloadedResolver` mapping the specified file(s) to the desired substitutions. This has many advantages:

1. There is no file access, hopefully resolving the concurrency issues.
2. This leaves the examples unchanged from the specs.
3. `XmlPreloadedResolver` throws an exception when a reference is unresolved whereas `XmlUrlResolver` returns an empty string. This is better behavior for tests.

I have cleaned up a few more tests while I was there. Most of the Transform tests appear to be copies of each other so there is scope to combine or parameterize these in the future.

CC: @krwq @tintoy @peterwurzinger